### PR TITLE
Accept "Gene ID" column name and translate to "gene_id"

### DIFF
--- a/bin/import
+++ b/bin/import
@@ -116,14 +116,11 @@ sub validateTextFile {
   my $header = <DATA>;
   chomp($header);
 
-  if ($header =~ /tracking_id\tclass_code\tnearest_ref_id\t(?:gene_id|Gene ID)\tgene_short_name\ttss_id\tlocus\tlength\tcoverage\tFPKM\tFPKM_conf_lo\tFPKM_conf_hi\tFPKM_status/) {
+  if ($header =~ /^tracking_id\tclass_code\tnearest_ref_id\t(?:gene_id|Gene ID)\tgene_short_name\ttss_id\tlocus\tlength\tcoverage\tFPKM\tFPKM_conf_lo\tFPKM_conf_hi\tFPKM_status$/) {
     # Cufflinks FPKM file
     $columnCount = 13
-  } elsif ($header =~ /(?:gene_id|Gene ID)\tFPKM/) {
-    # FPKMtool file
-    $columnCount = 2;
-  } elsif ($header =~ /(?:gene_id|Gene ID)\tTPM/) {
-    # TPMtool file
+  } elsif ($header =~ /^(?:gene_id|Gene ID)\t(?:FPKM|TPM)$/) {
+    # FPKMtool or TPMtool file
     $columnCount = 2;
   } else {
     validationError("Unrecognized header record. Not a valid transcript abundance file. Must have 'gene_id' in the first column and either 'FPKM' or 'TPM' in the second column, or, for a cufflinks file, have FPKM in the 10th column. File: $baseFile");

--- a/bin/import
+++ b/bin/import
@@ -102,7 +102,20 @@ sub copyDataFile {
   my ($dataFile) = @_;
   my $out = $dataFile;
   my $out =~ s/[^\.-\w]/_/g;  # replace icky chars with underscore
-  copy("$inputDir/$dataFile", "$outputDir/$out");
+
+  # Copy the contents of the input file to a safe-named output file, replacing
+  # "Gene ID" with "gene_id" in the header line if necessary.
+  open(IN, '<'.$dataFile) or die $!;
+  open(OUT, '>'.$out) or die $!;
+  while (<IN>) {
+    if ($. == 1) {
+      print OUT s/Gene ID/gene_id/;
+    } else {
+      print OUT;
+    }
+  }
+  close(IN);
+  close(OUT);
 }
 
 sub validateTextFile {
@@ -115,13 +128,13 @@ sub validateTextFile {
   my $header = <DATA>;
   chomp($header);
 
-  if ($header eq "tracking_id\tclass_code\tnearest_ref_id\tgene_id\tgene_short_name\ttss_id\tlocus\tlength\tcoverage\tFPKM\tFPKM_conf_lo\tFPKM_conf_hi\tFPKM_status") {
+  if ($header =~ /tracking_id\tclass_code\tnearest_ref_id\t(?:gene_id|Gene ID)\tgene_short_name\ttss_id\tlocus\tlength\tcoverage\tFPKM\tFPKM_conf_lo\tFPKM_conf_hi\tFPKM_status/) {
     # Cufflinks FPKM file
     $columnCount = 13
-  } elsif ($header eq "gene_id\tFPKM") {
+  } elsif ($header =~ /(?:gene_id|Gene ID)\tFPKM/) {
     # FPKMtool file
     $columnCount = 2;
-  } elsif ($header eq "gene_id\tTPM") {
+  } elsif ($header =~ /(?:gene_id|Gene ID)\tTPM/) {
     # TPMtool file
     $columnCount = 2;
   } else {

--- a/bin/import
+++ b/bin/import
@@ -87,6 +87,7 @@ sub validateAndCopyFiles {
 
   } while(($sampleName, $filename) = readAndValidateManifestLine($fh, $inputDir));
 }
+
 sub validateDataFileName {
   my ($filename) = @_;
 
@@ -102,20 +103,7 @@ sub copyDataFile {
   my ($dataFile) = @_;
   my $out = $dataFile;
   my $out =~ s/[^\.-\w]/_/g;  # replace icky chars with underscore
-
-  # Copy the contents of the input file to a safe-named output file, replacing
-  # "Gene ID" with "gene_id" in the header line if necessary.
-  open(IN, '<'.$dataFile) or die $!;
-  open(OUT, '>'.$out) or die $!;
-  while (<IN>) {
-    if ($. == 1) {
-      print OUT s/Gene ID/gene_id/;
-    } else {
-      print OUT;
-    }
-  }
-  close(IN);
-  close(OUT);
+  copy("$inputDir/$dataFile", "$outputDir/$out");
 }
 
 sub validateTextFile {

--- a/bin/install-data
+++ b/bin/install-data
@@ -194,30 +194,23 @@ sub installTxtFile {
   print STDERR "executing insert protocol app node $psId $panId $panName $orderNum\n if $DEBUG";
   $insertProtocolAppNode->execute($panId, $psId, $panName, $orderNum);
 
-  my ($idIndex, $fpkmIndex);
   print STDERR "opening fpkm file $filename\n if $DEBUG";
   open(DAT, $filename) or die "Cannot open file $filename for reading: $!";
 
   # check header to distinguish file type
-  my $unit;
   my $header = <DAT>;
   chomp($header);
 
-  if ($header eq "tracking_id\tclass_code\tnearest_ref_id\tgene_id\tgene_short_name\ttss_id\tlocus\tlength\tcoverage\tFPKM\tFPKM_conf_lo\tFPKM_conf_hi\tFPKM_status") {
-    # Cufflinks FPKM file
-    $idIndex = 0;
+  my $idIndex = 0;
+  my $fpkmIndex;
+  my $unit;
+
+  if ($header =~ tr/\t// == 12) {        # Cufflinks FPKM file has 13 columns (12 delimiters)
+    $unit = "FPKM";
     $fpkmIndex = 9;
-    $unit = "FPKM";
-  } elsif ($header eq "gene_id\tFPKM") {
-    # FPKMtool file
-    $idIndex = 0;
+  } elsif ($header =~ /\t(FPKM|TPM)$/) { # FPKMtool or TPMtool file
+    $unit = $1;
     $fpkmIndex = 1;
-    $unit = "FPKM";
-  } elsif ($header eq "gene_id\tTPM") {
-    # TPMtool file
-    $idIndex = 0;
-    $fpkmIndex = 1;
-    $unit = "TPM";
   } else {
     validationError("Unrecognized header record. Not a valid transcript abundance file. File: $filename");
   }


### PR DESCRIPTION
Updates:

* data file header line test now accepts either "Gene ID" or "gene_id" instead of just "gene_id"
* install-data script no longer does duplicate header validation, and thus will accept "Gene ID" as a column header